### PR TITLE
Added basic functionality for spiral test

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.bethanywong.msapp">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"
@@ -17,7 +18,7 @@
         </activity>
         <activity android:name=".test">
             <intent-filter>
-                <action android:name="com.example.bethanywong.msapp.test" />
+                <action android:name="com.example.bethanywong.msapp.TapTest" />
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
@@ -25,6 +26,13 @@
         <activity android:name=".DeveloperInfo">
             <intent-filter>
                 <action android:name="com.example.bethanywong.msapp.DeveloperInfo" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".SpiralTest">
+            <intent-filter>
+                <action android:name="com.example.bethanywong.msapp.SpiralTest" />
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/app/src/main/java/com/example/bethanywong/msapp/DrawingView.java
+++ b/app/src/main/java/com/example/bethanywong/msapp/DrawingView.java
@@ -1,0 +1,70 @@
+package com.example.bethanywong.msapp;
+
+import android.content.Context;
+import android.view.View;
+import android.util.AttributeSet;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.view.MotionEvent;
+
+public class DrawingView extends View {
+    private Path drawPath;
+    private Paint drawPaint, canvasPaint;
+    private Canvas drawCanvas;
+    private Bitmap canvasBitmap;
+
+    public DrawingView(Context context, AttributeSet attrs){
+        super(context,attrs);
+        setupDrawing();
+    }
+
+    private void setupDrawing(){
+        drawPath = new Path();
+        drawPaint = new Paint();
+        drawPaint.setColor(0xFFFF0000);
+        drawPaint.setAntiAlias(true);
+        drawPaint.setStrokeWidth(45);
+        drawPaint.setStyle(Paint.Style.STROKE);
+        drawPaint.setStrokeJoin(Paint.Join.ROUND);
+        drawPaint.setStrokeCap(Paint.Cap.ROUND);
+        canvasPaint = new Paint(Paint.DITHER_FLAG);
+    }
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        canvasBitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        drawCanvas = new Canvas(canvasBitmap);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        canvas.drawBitmap(canvasBitmap, 0, 0, canvasPaint);
+        canvas.drawPath(drawPath, drawPaint);
+    }
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        float touchX = event.getX();
+        float touchY = event.getY();
+
+        //i know, switch cases lmao
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                drawPath.moveTo(touchX, touchY);
+                break;
+            case MotionEvent.ACTION_MOVE:
+                drawPath.lineTo(touchX, touchY);
+                break;
+            case MotionEvent.ACTION_UP:
+                drawCanvas.drawPath(drawPath, drawPaint);
+                drawPath.reset();
+                break;
+            default:
+                return false;
+        }
+        invalidate();
+        return true;
+    }
+
+}

--- a/app/src/main/java/com/example/bethanywong/msapp/MainActivity.java
+++ b/app/src/main/java/com/example/bethanywong/msapp/MainActivity.java
@@ -18,12 +18,22 @@ public class MainActivity extends AppCompatActivity {
 
     public void OnClickButtonListener() {
         Button test1_button = (Button)findViewById(R.id.tap_button);
+        Button test2_button = (Button)findViewById(R.id.spiral_button);
         Button devinfo_button = (Button)findViewById(R.id.devinfo_button);
         test1_button.setOnClickListener(
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Intent intent = new Intent("com.example.bethanywong.msapp.test");
+                        Intent intent = new Intent("com.example.bethanywong.msapp.TapTest");
+                        startActivity(intent);
+                    }
+                }
+        );
+        test2_button.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        Intent intent = new Intent("com.example.bethanywong.msapp.SpiralTest");
                         startActivity(intent);
                     }
                 }

--- a/app/src/main/java/com/example/bethanywong/msapp/SpiralTest.java
+++ b/app/src/main/java/com/example/bethanywong/msapp/SpiralTest.java
@@ -1,0 +1,61 @@
+package com.example.bethanywong.msapp;
+
+import android.Manifest;
+import android.view.View;
+import android.content.pm.PackageManager;
+import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import java.util.UUID;
+
+public class SpiralTest extends AppCompatActivity {
+
+    private View view;
+    private static final int PERMISSION_REQUEST_CODE = 1;
+    private DrawingView drawView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_spiral_test);
+        drawView = (DrawingView)findViewById(R.id.drawing);
+    }
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+      if (requestCode == PERMISSION_REQUEST_CODE){
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                //if permission wasn't granted the first time, call save drawing again.
+                //reason we call again is because the permission request is async, pls help with the callback pls
+                saveDrawing(view);
+            } else {
+                //some error handling lolz
+            }
+        }
+    }
+
+    public void saveDrawing(View v){
+        view = v;
+        if (ActivityCompat.checkSelfPermission(getApplicationContext(),Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED){
+                ActivityCompat.requestPermissions(this,new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},PERMISSION_REQUEST_CODE);
+        } else {
+            drawView.setDrawingCacheEnabled(true);
+            String imgSaved = MediaStore.Images.Media.insertImage(
+                    getContentResolver(), drawView.getDrawingCache(),
+                    UUID.randomUUID().toString() + ".png", "drawing");
+            if (imgSaved != null) {
+                Toast savedToast = Toast.makeText(getApplicationContext(),
+                        "Drawing saved to Gallery!", Toast.LENGTH_SHORT);
+                savedToast.show();
+            } else {
+                Toast unsavedToast = Toast.makeText(getApplicationContext(),
+                        "Oops! Image could not be saved.", Toast.LENGTH_SHORT);
+                unsavedToast.show();
+            }
+            drawView.destroyDrawingCache();
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_black_bold_spiral.xml
+++ b/app/src/main/res/drawable/ic_black_bold_spiral.xml
@@ -1,0 +1,7 @@
+<vector android:height="24dp" android:viewportHeight="47.47174"
+    android:viewportWidth="47.47174" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="0.75" android:fillColor="#00000000"
+        android:pathData="M22,24.87C22.3,23.87 20.8,23.97 20.34,24.37C19.08,25.45 19.84,27.4 21.01,28.2C23.09,29.62 25.87,28.42 27,26.36C28.65,23.34 26.96,19.63 24,18.21C20.05,16.31 15.39,18.51 13.68,22.38C11.52,27.24 14.25,32.87 19.01,34.86C24.79,37.28 31.39,34.03 33.66,28.35C36.34,21.67 32.56,14.09 25.99,11.54C18.4,8.6 9.84,12.9 7.01,20.38C3.8,28.88 8.63,38.42 17.02,41.52C26.43,45 36.95,39.64 40.32,30.35C44.07,20.03 38.18,8.53 27.98,4.88"
+        android:strokeAlpha="1" android:strokeColor="#000000"
+        android:strokeLineCap="round" android:strokeLineJoin="miter" android:strokeWidth="4"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,6 +18,23 @@
         android:layout_width="match_parent"
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true" />
+    <Button
+        android:text="Spiral Test"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/spiral_button"
+        android:layout_marginTop="23dp"
+        android:layout_below="@+id/tap_button"
+        android:layout_centerHorizontal="true" />
+
+    <Button
+        android:text="View Past Results"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/results_button"
+        android:layout_marginTop="23dp"
+        android:layout_below="@+id/spiral_button"
+        android:layout_centerHorizontal="true" />
 
     <Button
         android:text="Developers Info"
@@ -28,12 +45,5 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true" />
 
-    <Button
-        android:text="View Past Results"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/results_button"
-        android:layout_marginTop="23dp"
-        android:layout_below="@+id/tap_button"
-        android:layout_centerHorizontal="true" />
+
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_spiral_test.xml
+++ b/app/src/main/res/layout/activity_spiral_test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_spiral_test"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:screenOrientation="portrait"
+    tools:context="com.example.bethanywong.msapp.SpiralTest">
+
+    <com.example.bethanywong.msapp.DrawingView
+        android:id="@+id/drawing"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_alignTop="@+id/spiral"
+        android:layout_alignBottom="@+id/spiral"
+        android:layout_alignRight="@+id/spiral"
+        android:layout_alignLeft="@+id/spiral"
+        android:layout_alignStart="@+id/spiral"
+        android:layout_alignEnd="@+id/spiral"
+         />
+
+    <ImageView
+        android:layout_width="600px"
+        android:layout_height="600px"
+        android:alpha = "0.5"
+        android:src="@drawable/ic_black_bold_spiral"
+        android:id = "@+id/spiral"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true" />
+
+    <Button
+        android:text="Save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:id="@+id/save"
+        android:onClick="saveDrawing"/>
+
+</RelativeLayout>


### PR DESCRIPTION
![e2](https://cloud.githubusercontent.com/assets/14339463/22902163/2558a848-f202-11e6-9d01-6848a398a871.gif)
<sub>lmao i suck at drawing</sub>

Changes
-update main page with option to go to spiral test
-added spiral image
-record user input on screen while tracing over image
-allows users to draw on the screen with some color on top of spiral picture (like bright red?)
-save image of user drawn spiral
--changed intent of test to TapTest to avoid confusion(was originally just test, should continue to refactor to TapTest, since we don't have just one test now)

There's probably a better way to request permissions, but this is pretty much the same way I've saved the tap test data, to be pushed in a later pr.

I'm not sure how exactly we're going to measure accuracy here. Overlay the spiral vector and determine how many pixels are red (drawing went out of bounds) and determine an accuracy metric from there?
